### PR TITLE
Use benchmark_driver for better benchmark isolation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gem "solid_queue", "~> 0.3"
 gem "pg", "~> 1.5"
 
 gem "ruby-prof", "~> 1.7"
+
+gem "benchmark_driver", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       mutex_m
       tzinfo (~> 2.0)
     base64 (0.2.0)
+    benchmark_driver (0.16.5)
     bigdecimal (3.1.8)
     builder (3.3.0)
     concurrent-ruby (1.3.3)
@@ -218,6 +219,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  benchmark_driver
   good_job (~> 3.0)
   pg (~> 1.5)
   rails (~> 7.1)

--- a/README.md
+++ b/README.md
@@ -23,25 +23,41 @@ rake db:drop db:create db:migrate
 
 ## Run the Benchmarks
 
-`bin/rails r bench.rb`
+```
+ruby bench.rb
+```
 
 ## Results
 
 You'll see something similar to:
 
 ```
-%  bin/rails r bench.rb                                 
-2024-06-26T00:05:53.654Z pid=80843 tid=1jkn INFO: Sidekiq 7.3.0 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>nil}
-                                user     system      total        real
-ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [arm64-darwin23]
-{:rails=>"7.1.3.4", :good_job=>"3.29.5", :sidekiq=>"7.3.0", :solid_queue=>"0.3.3"}
-Benchmarking with 10000 jobs
-good_job-pushbulk           2.055545   0.062931   2.118476 (  2.422912)
-good_job-push               7.518458   0.700281   8.218739 ( 14.382432)
-sidekiq-push                0.762180   0.112616   0.874796 (  1.082766)
-solid_queue-push            6.801042   0.841682   7.642724 ( 13.299562)
-sidekiq-native-enq          0.277043   0.064306   0.341349 (  0.493235)
-sidekiq-native-enq-bulk     0.061961   0.001396   0.063357 (  0.066778)
+$ ruby bench.rb
+ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [x86_64-linux]
+{:rails=>"7.1.3.4", :good_job=>"3.29.5", :sidekiq=>"7.2.4", :solid_queue=>"0.3.3"}
+Benchmarking with 1000 jobs per iteration
+Warming up --------------------------------------
+          good_job-push      0.654 i/s -       1.000 times in 1.529646s (1.53s/i)
+      good_job-pushbulk      2.617 i/s -       3.000 times in 1.146226s (382.08ms/i)
+       solid_queue-push      0.527 i/s -       1.000 times in 1.898825s (1.90s/i)
+           sidekiq-push      7.407 i/s -       8.000 times in 1.079990s (135.00ms/i)
+     sidekiq-native-enq     19.492 i/s -      21.000 times in 1.077352s (51.30ms/i)
+sidekiq-native-enq-bulk    150.399 i/s -     165.000 times in 1.097080s (6.65ms/i)
+Calculating -------------------------------------
+          good_job-push      0.668 i/s -       1.000 times in 1.496906s (1.50s/i)
+      good_job-pushbulk      2.615 i/s -       7.000 times in 2.676486s (382.36ms/i)
+       solid_queue-push      0.505 i/s -       1.000 times in 1.978678s (1.98s/i)
+           sidekiq-push      7.750 i/s -      22.000 times in 2.838791s (129.04ms/i)
+     sidekiq-native-enq     19.911 i/s -      58.000 times in 2.912960s (50.22ms/i)
+sidekiq-native-enq-bulk    148.810 i/s -     451.000 times in 3.030703s (6.72ms/i)
+
+Comparison:
+sidekiq-native-enq-bulk:       148.8 i/s
+     sidekiq-native-enq:        19.9 i/s - 7.47x  slower
+           sidekiq-push:         7.7 i/s - 19.20x  slower
+      good_job-pushbulk:         2.6 i/s - 56.90x  slower
+          good_job-push:         0.7 i/s - 222.76x  slower
+       solid_queue-push:         0.5 i/s - 294.45x  slower
 ```
 
 TODO: Execution profiling?


### PR DESCRIPTION
[Standard `Benchmark.bm` method](https://github.com/ruby/benchmark) used now has multiple drawbacks:
 - it runs every reported block only once (which can lead to high variability between runs)
 - it runs reported blocks sequentially, which possibly can skew results for later block. For example, first blocks maybe slower due to constant autoloading, and last blocks maybe faster due to YJIT may start to optimize code (though bottleneck should be in the Redis/PostgreSQL, but the fact that YJIT is mentioned in README makes me wonder about possible impact on results)
 - reports are not easily readable and comparable

[benchmark-driver](https://github.com/benchmark-driver/benchmark-driver) solves these by doing following:
 - like [benchmark-ips](https://github.com/evanphx/benchmark-ips), it executes every reported script multiple times and reports iterations per second to reduce execution time variability impact (that's why I got rid from `outer = 10` as iterations setting)
 - it runs every reported script as separate program, completely independently from other reports, also it pre-executes every reported script to allow constants to preload and YJIT to warm up (and databases caches too)
 - reports has sorted summary with all results compared with the fastest one

The result:

```
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [x86_64-linux]
{:rails=>"7.1.3.4", :good_job=>"3.29.5", :sidekiq=>"7.2.4", :solid_queue=>"0.3.3"}
Benchmarking with 1000 jobs per iteration
Warming up --------------------------------------
          good_job-push      0.654 i/s -       1.000 times in 1.529646s (1.53s/i)
      good_job-pushbulk      2.617 i/s -       3.000 times in 1.146226s (382.08ms/i)
       solid_queue-push      0.527 i/s -       1.000 times in 1.898825s (1.90s/i)
           sidekiq-push      7.407 i/s -       8.000 times in 1.079990s (135.00ms/i)
     sidekiq-native-enq     19.492 i/s -      21.000 times in 1.077352s (51.30ms/i)
sidekiq-native-enq-bulk    150.399 i/s -     165.000 times in 1.097080s (6.65ms/i)
Calculating -------------------------------------
          good_job-push      0.668 i/s -       1.000 times in 1.496906s (1.50s/i)
      good_job-pushbulk      2.615 i/s -       7.000 times in 2.676486s (382.36ms/i)
       solid_queue-push      0.505 i/s -       1.000 times in 1.978678s (1.98s/i)
           sidekiq-push      7.750 i/s -      22.000 times in 2.838791s (129.04ms/i)
     sidekiq-native-enq     19.911 i/s -      58.000 times in 2.912960s (50.22ms/i)
sidekiq-native-enq-bulk    148.810 i/s -     451.000 times in 3.030703s (6.72ms/i)

Comparison:
sidekiq-native-enq-bulk:       148.8 i/s 
     sidekiq-native-enq:        19.9 i/s - 7.47x  slower
           sidekiq-push:         7.7 i/s - 19.20x  slower
      good_job-pushbulk:         2.6 i/s - 56.90x  slower
          good_job-push:         0.7 i/s - 222.76x  slower
       solid_queue-push:         0.5 i/s - 294.45x  slower
```

P.S> During review use “hide whitespace-only changes” mode to reduce diff size