### PR TITLE
Add solid_queue-pushbulk report

### DIFF
--- a/bench.rb
+++ b/bench.rb
@@ -50,6 +50,13 @@ Benchmark.driver do |x|
     end
   RUBY
 
+  x.report "solid_queue-pushbulk", <<~RUBY
+    ActiveJob::Base.queue_adapter = :solid_queue
+    ActiveJob.perform_all_later jobs.times.map do
+      RoundupJob.new(123, "hello world", hash)
+    end
+  RUBY
+
   x.report "sidekiq-push", <<~RUBY
     ActiveJob::Base.queue_adapter = :sidekiq
     jobs.times do

--- a/bench.rb
+++ b/bench.rb
@@ -52,9 +52,9 @@ Benchmark.driver do |x|
 
   x.report "solid_queue-pushbulk", <<~RUBY
     ActiveJob::Base.queue_adapter = :solid_queue
-    ActiveJob.perform_all_later jobs.times.map do
+    ActiveJob.perform_all_later(jobs.times.map do
       RoundupJob.new(123, "hello world", hash)
-    end
+    end)
   RUBY
 
   x.report "sidekiq-push", <<~RUBY


### PR DESCRIPTION
ActiveJob now (since 7.1) supports `ActiveJob.perform_all_later` as a bulk enqueuing mechanism. And Solid Queue implements the appropriate interface (see https://github.com/rails/solid_queue/blob/f0ca6b43b5cefc97b40e3154be6ee535d77b8450/app/models/solid_queue/job.rb#L12). We should add this to the roundup.