### PR TITLE
Add ActiveJob.perform_all_later and some tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,12 @@ rake db:create
 bin/rails g good_job:install
 rake solid_queue:install:migrations
 rake db:migrate
-export RUBY_YJIT_ENABLE=1
-```
-
-## Between Runs
-
-```
-redis-cli flushall
-rake db:drop db:create db:migrate
 ```
 
 ## Run the Benchmarks
 
 ```
-ruby bench.rb
+bin/bench
 ```
 
 ## Results
@@ -32,32 +24,43 @@ ruby bench.rb
 You'll see something similar to:
 
 ```
-$ ruby bench.rb
-ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [x86_64-linux]
+$ bin/bench
+
+ruby 3.3.4 (2024-07-09 revision be1089c8ec) +YJIT [arm64-darwin23]
 {:rails=>"7.1.3.4", :good_job=>"3.29.5", :sidekiq=>"7.2.4", :solid_queue=>"0.3.3"}
 Benchmarking with 1000 jobs per iteration
+==== Single Enqueue ====
 Warming up --------------------------------------
-          good_job-push      0.654 i/s -       1.000 times in 1.529646s (1.53s/i)
-      good_job-pushbulk      2.617 i/s -       3.000 times in 1.146226s (382.08ms/i)
-       solid_queue-push      0.527 i/s -       1.000 times in 1.898825s (1.90s/i)
-           sidekiq-push      7.407 i/s -       8.000 times in 1.079990s (135.00ms/i)
-     sidekiq-native-enq     19.492 i/s -      21.000 times in 1.077352s (51.30ms/i)
-sidekiq-native-enq-bulk    150.399 i/s -     165.000 times in 1.097080s (6.65ms/i)
+            good_job      2.270 i/s -       3.000 times in 1.321639s (440.55ms/i)
+         solid_queue      1.711 i/s -       2.000 times in 1.168985s (584.49ms/i)
+             sidekiq     16.484 i/s -      18.000 times in 1.091964s (60.66ms/i)
+      sidekiq-native     26.912 i/s -      27.000 times in 1.003259s (37.16ms/i)
 Calculating -------------------------------------
-          good_job-push      0.668 i/s -       1.000 times in 1.496906s (1.50s/i)
-      good_job-pushbulk      2.615 i/s -       7.000 times in 2.676486s (382.36ms/i)
-       solid_queue-push      0.505 i/s -       1.000 times in 1.978678s (1.98s/i)
-           sidekiq-push      7.750 i/s -      22.000 times in 2.838791s (129.04ms/i)
-     sidekiq-native-enq     19.911 i/s -      58.000 times in 2.912960s (50.22ms/i)
-sidekiq-native-enq-bulk    148.810 i/s -     451.000 times in 3.030703s (6.72ms/i)
+            good_job      2.218 i/s -       6.000 times in 2.705422s (450.90ms/i)
+         solid_queue      1.611 i/s -       5.000 times in 3.103893s (620.78ms/i)
+             sidekiq     16.159 i/s -      49.000 times in 3.032280s (61.88ms/i)
+      sidekiq-native     26.112 i/s -      80.000 times in 3.063720s (38.30ms/i)
 
 Comparison:
-sidekiq-native-enq-bulk:       148.8 i/s
-     sidekiq-native-enq:        19.9 i/s - 7.47x  slower
-           sidekiq-push:         7.7 i/s - 19.20x  slower
-      good_job-pushbulk:         2.6 i/s - 56.90x  slower
-          good_job-push:         0.7 i/s - 222.76x  slower
-       solid_queue-push:         0.5 i/s - 294.45x  slower
+      sidekiq-native:        26.1 i/s
+             sidekiq:        16.2 i/s - 1.62x  slower
+            good_job:         2.2 i/s - 11.77x  slower
+         solid_queue:         1.6 i/s - 16.21x  slower
+
+==== Bulk Enqueue ====
+Warming up --------------------------------------
+            good_job      7.671 i/s -       8.000 times in 1.042856s (130.36ms/i)
+             sidekiq     82.011 i/s -      88.000 times in 1.073021s (12.19ms/i)
+      sidekiq-native    180.868 i/s -     190.000 times in 1.050491s (5.53ms/i)
+Calculating -------------------------------------
+            good_job      7.192 i/s -      23.000 times in 3.198037s (139.05ms/i)
+             sidekiq     80.518 i/s -     246.000 times in 3.055228s (12.42ms/i)
+      sidekiq-native    179.980 i/s -     542.000 times in 3.011441s (5.56ms/i)
+
+Comparison:
+      sidekiq-native:       180.0 i/s
+             sidekiq:        80.5 i/s - 2.24x  slower
+            good_job:         7.2 i/s - 25.03x  slower
 ```
 
 TODO: Execution profiling?

--- a/app/jobs/roundup_job.rb
+++ b/app/jobs/roundup_job.rb
@@ -1,3 +1,15 @@
 class RoundupJob < ApplicationJob
   queue_as :default
+
+  class Sidekiq < RoundupJob
+    self.queue_adapter = :sidekiq
+  end
+
+  class Goodjob < RoundupJob
+    self.queue_adapter = :good_job
+  end
+
+  class Solidqueue < RoundupJob
+    self.queue_adapter = :solid_queue
+  end
 end

--- a/bin/bench
+++ b/bin/bench
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+export RUBY_YJIT_ENABLE=1
+export RAILS_ENV=production
+export SECRET_KEY_BASE=0
+export DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+
+bin/rake db:drop db:create db:migrate
+redis-cli flushall
+
+exec bin/bundle exec ruby bench.rb

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,62 +23,10 @@ development:
   <<: *default
   database: job_roundup_development
 
-  # The specified database role being used to connect to PostgreSQL.
-  # To create additional roles in PostgreSQL see `$ createuser --help`.
-  # When left blank, PostgreSQL will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: job_roundup
-
-  # The password associated with the PostgreSQL role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: job_roundup_test
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
 production:
   <<: *default
   database: job_roundup_production
-  username: job_roundup
-  password: <%= ENV["JOB_ROUNDUP_DATABASE_PASSWORD"] %>


### PR DESCRIPTION
- Split single enqueue and bulk benchmaks to make it easier to read.
- Add `bin/bench` script to re-run in a single command
- Configure Rails and AJ in production mode.
- Run benchmarks with frozen string literals.
- Define dedicated job classes rather than re-assign `queue_adapter` to avoid trashing caches.